### PR TITLE
Refactor onboarding flow and pantry state

### DIFF
--- a/app.example.json
+++ b/app.example.json
@@ -34,6 +34,7 @@
     "firebaseProjectId": "<YOUR_PROJECT_ID>",
     "firebaseStorageBucket": "<YOUR_STORAGE_BUCKET>",
     "firebaseMessagingSenderId": "<YOUR_SENDER_ID>",
-    "firebaseAppId": "<YOUR_APP_ID>"
+    "firebaseAppId": "<YOUR_APP_ID>",
+    "spoonacularProxyUrl": "<YOUR_BACKEND_PROXY_URL>"
   }
 }

--- a/desire-app-v2/app.json
+++ b/desire-app-v2/app.json
@@ -26,6 +26,9 @@
     },
     "web": {
       "favicon": "./assets/app-icon.png"
+    },
+    "extra": {
+      "spoonacularProxyUrl": "https://your-cloud-function-url"
     }
   }
 }

--- a/desire-app-v2/src/api/spoonacular.ts
+++ b/desire-app-v2/src/api/spoonacular.ts
@@ -23,14 +23,11 @@ export interface RecipeDetails {
   extendedIngredients: Array<{ id: number; name: string; amount: number; unit: string }>;
 }
 
-// Create a configured Axios instance. The API key is provided via expo config.
+// Create a configured Axios instance that points to the backend proxy. The
+// actual Spoonacular API key is stored securely on the server and appended by
+// the proxy function, keeping it out of the client bundle.
 const api: AxiosInstance = axios.create({
-  baseURL: 'https://api.spoonacular.com/',
-  // Note: The API key is sent as a query parameter rather than a header because
-  // the Spoonacular API does not honour custom headers for authentication.
-  params: {
-    apiKey: Constants?.expoConfig?.extra?.spoonacularApiKey,
-  },
+  baseURL: Constants?.expoConfig?.extra?.spoonacularProxyUrl,
 });
 
 /**
@@ -41,8 +38,9 @@ const api: AxiosInstance = axios.create({
  */
 export async function searchRecipes(query: string): Promise<RecipeSummary[]> {
   try {
-    const response = await api.get('recipes/complexSearch', {
+    const response = await api.get('', {
       params: {
+        endpoint: 'recipes/complexSearch',
         query,
         number: 10,
       },
@@ -62,8 +60,9 @@ export async function searchRecipes(query: string): Promise<RecipeSummary[]> {
  */
 export async function getRecipeDetails(id: number): Promise<RecipeDetails> {
   try {
-    const response = await api.get(`recipes/${id}/information`, {
+    const response = await api.get('', {
       params: {
+        endpoint: `recipes/${id}/information`,
         includeNutrition: false,
       },
     });

--- a/desire-app-v2/src/components/common/Button.tsx
+++ b/desire-app-v2/src/components/common/Button.tsx
@@ -22,7 +22,12 @@ interface ButtonProps {
  */
 export const Button: React.FC<ButtonProps> = ({ label, onPress, style }) => {
   return (
-    <Pressable style={({ pressed }) => [styles.button, style, pressed && styles.pressed]} onPress={onPress}>
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={({ pressed }) => [styles.button, style, pressed && styles.pressed]}
+      onPress={onPress}
+    >
       <Text style={styles.label}>{label}</Text>
     </Pressable>
   );

--- a/desire-app-v2/src/components/common/RecipeCard.tsx
+++ b/desire-app-v2/src/components/common/RecipeCard.tsx
@@ -23,7 +23,12 @@ interface RecipeCardProps {
  */
 export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, onPress, style }) => {
   return (
-    <Pressable onPress={onPress} style={[styles.container, style]}>
+    <Pressable
+      onPress={onPress}
+      accessibilityLabel={`Recipe for ${recipe.title}`}
+      accessibilityRole="button"
+      style={[styles.container, style]}
+    >
       <ImageBackground source={{ uri: recipe.image }} style={styles.image} imageStyle={styles.imageStyle}>
         <View style={styles.overlay}>
           <Text style={styles.title} numberOfLines={2}>{recipe.title}</Text>

--- a/desire-app-v2/src/constants/navigation.ts
+++ b/desire-app-v2/src/constants/navigation.ts
@@ -1,0 +1,14 @@
+export const ROUTES = {
+  WELCOME: 'Welcome',
+  ARCHETYPE: 'Archetype',
+  CHECKLIST: 'Checklist',
+  ADVANCED_SETUP: 'AdvancedSetup',
+  HOME: 'Home',
+  RESULTS: 'Results',
+  SHOPPING_LIST: 'ShoppingList',
+  PANTRY_MANAGEMENT: 'PantryManagement',
+  LOGIN: 'Login',
+  SIGN_UP: 'SignUp',
+} as const;
+
+export type RouteName = (typeof ROUTES)[keyof typeof ROUTES];

--- a/desire-app-v2/src/hooks/useHomeScreenData.ts
+++ b/desire-app-v2/src/hooks/useHomeScreenData.ts
@@ -1,0 +1,40 @@
+import { useState, useMemo } from 'react';
+import { useUserStore } from '@store/userStore';
+import { markSearchPerformed } from '@utils/sessionService';
+
+export function useHomeScreenData() {
+  const [isEditing, setIsEditing] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const pantryLastUpdated = useUserStore((s) => s.pantryLastUpdated);
+  const consecutiveInactiveOpens = useUserStore((s) => s.consecutiveInactiveOpens);
+  const { resetInactiveOpens } = useUserStore((s) => s.actions);
+
+  const showEasterEgg = consecutiveInactiveOpens >= 3;
+  const promptText = showEasterEgg
+    ? 'The potential in your kitchen remains untapped. We trust you enjoyed your pre-packaged satisfaction.'
+    : 'What do you desire?';
+
+  const needsUpdate = pantryLastUpdated
+    ? Date.now() - pantryLastUpdated > 7 * 24 * 60 * 60 * 1000
+    : false;
+
+  const submit = (onSubmit: (q: string) => void) => {
+    if (!query.trim()) return;
+    resetInactiveOpens();
+    markSearchPerformed();
+    onSubmit(query.trim());
+    setQuery('');
+    setIsEditing(false);
+  };
+
+  return {
+    isEditing,
+    setIsEditing,
+    query,
+    setQuery,
+    promptText,
+    needsUpdate,
+    submit,
+  };
+}

--- a/desire-app-v2/src/hooks/usePantry.ts
+++ b/desire-app-v2/src/hooks/usePantry.ts
@@ -16,7 +16,7 @@ export function usePantryComparison(ingredients: string[]) {
     const need: string[] = [];
     ingredients.forEach((item) => {
       const lower = item.toLowerCase();
-      if (pantry.includes(lower)) {
+      if (pantry[lower]) {
         have.push(item);
       } else {
         need.push(item);

--- a/desire-app-v2/src/screens/Auth/LoginScreen.tsx
+++ b/desire-app-v2/src/screens/Auth/LoginScreen.tsx
@@ -9,6 +9,7 @@ import { fonts, sizes } from '@constants/typography';
 import { getAuthInstance } from '@config/firebase';
 import { signInWithEmailAndPassword } from 'firebase/auth';
 import { useToast } from '@components/common/Toast';
+import { ROUTES } from '@constants/navigation';
 
 /**
  * Screen allowing an existing user to sign into their account. Presents
@@ -16,7 +17,7 @@ import { useToast } from '@components/common/Toast';
  * authentication succeeds, Firebase will handle navigation via the
  * `useAuth` hook in the AppNavigator.
  */
-export type LoginScreenProps = NativeStackScreenProps<AuthStackParamList, 'Login'>;
+export type LoginScreenProps = NativeStackScreenProps<AuthStackParamList, typeof ROUTES.LOGIN>;
 
 const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
   const [email, setEmail] = useState('');
@@ -60,7 +61,7 @@ const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
         style={styles.input}
       />
       <Button label={isLoading ? 'Signing In...' : 'Sign In'} onPress={handleLogin} style={styles.button} />
-      <TouchableOpacity onPress={() => navigation.navigate('SignUp')}>
+      <TouchableOpacity onPress={() => navigation.navigate(ROUTES.SIGN_UP)}>
         <Text style={styles.linkText}>Don’t have an account? Sign up</Text>
       </TouchableOpacity>
     </View>

--- a/desire-app-v2/src/screens/Auth/SignUpScreen.tsx
+++ b/desire-app-v2/src/screens/Auth/SignUpScreen.tsx
@@ -9,13 +9,14 @@ import { fonts, sizes } from '@constants/typography';
 import { getAuthInstance } from '@config/firebase';
 import { createUserWithEmailAndPassword } from 'firebase/auth';
 import { useToast } from '@components/common/Toast';
+import { ROUTES } from '@constants/navigation';
 
 /**
  * Screen allowing a new user to create an account. Presents email and
  * password inputs along with a sign up button. Upon successful sign up
  * the authentication listener will redirect to the appropriate flow.
  */
-export type SignUpScreenProps = NativeStackScreenProps<AuthStackParamList, 'SignUp'>;
+export type SignUpScreenProps = NativeStackScreenProps<AuthStackParamList, typeof ROUTES.SIGN_UP>;
 
 const SignUpScreen: React.FC<SignUpScreenProps> = ({ navigation }) => {
   const [email, setEmail] = useState('');
@@ -59,7 +60,7 @@ const SignUpScreen: React.FC<SignUpScreenProps> = ({ navigation }) => {
         style={styles.input}
       />
       <Button label={isLoading ? 'Signing Up...' : 'Sign Up'} onPress={handleSignUp} style={styles.button} />
-      <TouchableOpacity onPress={() => navigation.navigate('Login')}>
+      <TouchableOpacity onPress={() => navigation.navigate(ROUTES.LOGIN)}>
         <Text style={styles.linkText}>Already have an account? Sign in</Text>
       </TouchableOpacity>
     </View>

--- a/desire-app-v2/src/screens/Main/ResultsScreen.tsx
+++ b/desire-app-v2/src/screens/Main/ResultsScreen.tsx
@@ -8,8 +8,9 @@ import { RecipeCard } from '@components/common/RecipeCard';
 import { colors } from '@constants/colors';
 import { fonts, sizes } from '@constants/typography';
 import { useToast } from '@components/common/Toast';
+import { ROUTES } from '@constants/navigation';
 
-type Props = NativeStackScreenProps<MainStackParamList, 'Results'>;
+type Props = NativeStackScreenProps<MainStackParamList, typeof ROUTES.RESULTS>;
 
 /**
  * Screen that presents search results fetched from the Spoonacular API. It
@@ -48,7 +49,7 @@ const ResultsScreen: React.FC<Props> = ({ route, navigation }) => {
     try {
       const details = await getRecipeDetails(recipe.id);
       const ingredientNames = details.extendedIngredients.map((ing) => ing.name);
-      navigation.navigate('ShoppingList', { title: recipe.title, ingredients: ingredientNames });
+      navigation.navigate(ROUTES.SHOPPING_LIST, { title: recipe.title, ingredients: ingredientNames });
     } catch (error) {
       showToast('Failed to fetch recipe details');
       // The ResultsScreen itself does not display details errors; rely on toast

--- a/desire-app-v2/src/screens/Onboarding/AdvancedSetupScreen.tsx
+++ b/desire-app-v2/src/screens/Onboarding/AdvancedSetupScreen.tsx
@@ -13,8 +13,9 @@ import type { PantryState } from '@store/pantryStore';
 import { useUserStore } from '@store/userStore';
 import type { UserState } from '@store/userStore';
 import { useToast } from '@components/common/Toast';
+import { ROUTES } from '@constants/navigation';
 
-type Props = NativeStackScreenProps<OnboardingStackParamList, 'AdvancedSetup'>;
+type Props = NativeStackScreenProps<OnboardingStackParamList, typeof ROUTES.ADVANCED_SETUP>;
 
 /**
  * Static category definitions for the advanced setup screen. In a real app
@@ -62,15 +63,19 @@ const AdvancedSetupScreen: React.FC<Props> = ({ navigation }) => {
         return;
       }
       await Promise.all(selected.map((item) => addItemToPantry(userId, item)));
-      pantryActions.setPantry(selected.map((i) => i.toLowerCase()));
+      const pantryObj: Record<string, boolean> = {};
+      selected.forEach((i) => {
+        pantryObj[i.toLowerCase()] = true;
+      });
+      pantryActions.setPantry(pantryObj);
       const timestamp = Date.now();
       await updateUserProfile(userId, {
         pantryLastUpdated: timestamp,
       });
       userActions.setPantryLastUpdated(timestamp);
-      await userActions.setHasOnboarded(true);
+      await userActions.setOnboardingStep('finished');
       userActions.resetInactiveOpens();
-      navigation.reset({ index: 0, routes: [{ name: 'Home' as never }] });
+      navigation.reset({ index: 0, routes: [{ name: ROUTES.HOME as never }] });
     } catch (error) {
       // Notify the user of the failure; avoid console.log in production
       showToast('Failed to save pantry');

--- a/desire-app-v2/src/screens/Onboarding/ArchetypeScreen.tsx
+++ b/desire-app-v2/src/screens/Onboarding/ArchetypeScreen.tsx
@@ -4,10 +4,12 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
 import { OnboardingStackParamList } from '@navigation/AppNavigator';
 import { ScreenContainer } from '@components/layout/ScreenContainer';
+import { useUserStore } from '@store/userStore';
 import { colors } from '@constants/colors';
 import { fonts, sizes } from '@constants/typography';
+import { ROUTES } from '@constants/navigation';
 
-type Navigation = NativeStackNavigationProp<OnboardingStackParamList, 'Archetype'>;
+type Navigation = NativeStackNavigationProp<OnboardingStackParamList, typeof ROUTES.ARCHETYPE>;
 
 /**
  * Definition of an archetype used for the lazy setup path. Each archetype has
@@ -63,9 +65,16 @@ const ArchetypeScreen: React.FC = () => {
   const { width } = Dimensions.get('window');
   const cardWidth = width * 0.8;
 
+  const setOnboardingStep = useUserStore((state) => state.actions.setOnboardingStep);
+  const setArchetype = useUserStore((state) => state.actions.setOnboardingArchetype);
+
   const renderItem = ({ item }: { item: Archetype }) => (
     <Pressable
-      onPress={() => navigation.navigate('Checklist', { archetype: item.title, ingredients: item.ingredients })}
+      onPress={() => {
+        setArchetype(item.title);
+        void setOnboardingStep('archetype_selected');
+        navigation.navigate(ROUTES.CHECKLIST, { archetype: item.title, ingredients: item.ingredients });
+      }}
       style={[styles.card, { width: cardWidth }]}
     >
       <ImageBackground source={item.image} style={styles.image} imageStyle={{ borderRadius: 8 }}>

--- a/desire-app-v2/src/screens/Onboarding/ChecklistScreen.tsx
+++ b/desire-app-v2/src/screens/Onboarding/ChecklistScreen.tsx
@@ -13,8 +13,9 @@ import type { PantryState } from '@store/pantryStore';
 import { useUserStore } from '@store/userStore';
 import type { UserState } from '@store/userStore';
 import { useToast } from '@components/common/Toast';
+import { ROUTES } from '@constants/navigation';
 
-type Props = NativeStackScreenProps<OnboardingStackParamList, 'Checklist'>;
+type Props = NativeStackScreenProps<OnboardingStackParamList, typeof ROUTES.CHECKLIST>;
 
 /**
  * Screen allowing the user to review and customise the list of pantry items
@@ -47,7 +48,11 @@ const ChecklistScreen: React.FC<Props> = ({ route, navigation }) => {
       await Promise.all(
         selected.map((item) => addItemToPantry(userId, item))
       );
-      pantryActions.setPantry(selected.map((i) => i.toLowerCase()));
+      const pantryObj: Record<string, boolean> = {};
+      selected.forEach((i) => {
+        pantryObj[i.toLowerCase()] = true;
+      });
+      pantryActions.setPantry(pantryObj);
       const timestamp = Date.now();
       await updateUserProfile(userId, {
         onboardingArchetype: archetype,
@@ -55,10 +60,10 @@ const ChecklistScreen: React.FC<Props> = ({ route, navigation }) => {
       });
       await userActions.setOnboardingArchetype(archetype);
       userActions.setPantryLastUpdated(timestamp);
-      await userActions.setHasOnboarded(true);
+      await userActions.setOnboardingStep('finished');
       // Reset inactive opens counter
       userActions.resetInactiveOpens();
-      navigation.reset({ index: 0, routes: [{ name: 'Home' as never }] });
+      navigation.reset({ index: 0, routes: [{ name: ROUTES.HOME as never }] });
     } catch (error) {
       // Display a user-friendly error via toast; avoid console logging to keep
       // production builds clean.

--- a/desire-app-v2/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/desire-app-v2/src/screens/Onboarding/WelcomeScreen.tsx
@@ -5,6 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 import { Button } from '@components/common/Button';
 import { ScreenContainer } from '@components/layout/ScreenContainer';
 import { OnboardingStackParamList } from '@navigation/AppNavigator';
+import { ROUTES } from '@constants/navigation';
 import { colors } from '@constants/colors';
 import { fonts, sizes } from '@constants/typography';
 
@@ -25,12 +26,12 @@ const WelcomeScreen: React.FC = () => {
         <View style={styles.buttonContainer}>
           <Button
             label="Lazy Setup"
-            onPress={() => navigation.navigate('Archetype')}
+            onPress={() => navigation.navigate(ROUTES.ARCHETYPE)}
             style={styles.button}
           />
           <Button
             label="Advanced Setup"
-            onPress={() => navigation.navigate('AdvancedSetup')}
+            onPress={() => navigation.navigate(ROUTES.ADVANCED_SETUP)}
             style={styles.button}
           />
         </View>

--- a/desire-app-v2/src/screens/Pantry/PantryManagementScreen.tsx
+++ b/desire-app-v2/src/screens/Pantry/PantryManagementScreen.tsx
@@ -12,8 +12,9 @@ import { colors } from '@constants/colors';
 import { fonts, sizes } from '@constants/typography';
 import { useToast } from '@components/common/Toast';
 import { Button } from '@components/common/Button';
+import { ROUTES } from '@constants/navigation';
 
-type Props = NativeStackScreenProps<MainStackParamList, 'PantryManagement'>;
+type Props = NativeStackScreenProps<MainStackParamList, typeof ROUTES.PANTRY_MANAGEMENT>;
 
 /**
  * Screen that allows the user to view and modify their current pantry.
@@ -79,7 +80,7 @@ const PantryManagementScreen: React.FC<Props> = () => {
         <Button label="Add" onPress={handleAdd} style={styles.addButton} />
       </View>
       <ScrollView contentContainerStyle={styles.listContainer}>
-        {items.map((item: string) => (
+        {Object.keys(items).map((item: string) => (
           <View key={item} style={styles.itemRow}>
             <Text style={styles.itemText}>{item}</Text>
             <TouchableOpacity onPress={() => handleRemove(item)}>
@@ -87,7 +88,7 @@ const PantryManagementScreen: React.FC<Props> = () => {
             </TouchableOpacity>
           </View>
         ))}
-        {items.length === 0 && (
+        {Object.keys(items).length === 0 && (
           <Text style={styles.empty}>Your pantry is empty. Start adding items!</Text>
         )}
       </ScrollView>

--- a/desire-app-v2/src/store/__tests__/pantryStore.test.ts
+++ b/desire-app-v2/src/store/__tests__/pantryStore.test.ts
@@ -1,0 +1,12 @@
+import { usePantryStore } from '../pantryStore';
+
+describe('pantryStore', () => {
+  it('adds and removes items', () => {
+    const { addItem, removeItem, resetPantry } = usePantryStore.getState().actions;
+    resetPantry();
+    addItem('sugar');
+    expect(usePantryStore.getState().items).toHaveProperty('sugar');
+    removeItem('sugar');
+    expect(usePantryStore.getState().items).not.toHaveProperty('sugar');
+  });
+});

--- a/desire-app-v2/src/store/__tests__/userStore.test.ts
+++ b/desire-app-v2/src/store/__tests__/userStore.test.ts
@@ -1,0 +1,11 @@
+import { act } from '@testing-library/react-native';
+import { useUserStore } from '../userStore';
+
+describe('userStore', () => {
+  it('updates onboarding step', async () => {
+    await act(async () => {
+      await useUserStore.getState().actions.setOnboardingStep('archetype_selected');
+    });
+    expect(useUserStore.getState().onboardingStep).toBe('archetype_selected');
+  });
+});

--- a/desire-app-v2/src/store/pantryStore.ts
+++ b/desire-app-v2/src/store/pantryStore.ts
@@ -5,10 +5,10 @@ import create from 'zustand';
  */
 export interface PantryState {
   /** The list of ingredient names currently stored in the user's pantry. */
-  items: string[];
+  items: Record<string, boolean>;
   actions: {
-    /** Replace the entire pantry with a new array of items. */
-    setPantry: (items: string[]) => void;
+    /** Replace the entire pantry with a new set of items. */
+    setPantry: (items: Record<string, boolean>) => void;
     /** Add a single item to the pantry. */
     addItem: (item: string) => void;
     /** Remove a single item from the pantry. */
@@ -27,11 +27,19 @@ export interface PantryState {
  * subscribe to `items` to reactively update when the pantry changes.
  */
 export const usePantryStore = create<PantryState>((set) => ({
-  items: [],
+  items: {},
   actions: {
-    setPantry: (items: string[]) => set({ items }),
-    addItem: (item: string) => set((state: PantryState) => ({ items: [...state.items, item.toLowerCase()] })),
-    removeItem: (item: string) => set((state: PantryState) => ({ items: state.items.filter((i) => i !== item.toLowerCase()) })),
-    resetPantry: () => set({ items: [] }),
+    setPantry: (items: Record<string, boolean>) => set({ items }),
+    addItem: (item: string) =>
+      set((state: PantryState) => ({
+        items: { ...state.items, [item.toLowerCase()]: true },
+      })),
+    removeItem: (item: string) =>
+      set((state: PantryState) => {
+        const updated = { ...state.items };
+        delete updated[item.toLowerCase()];
+        return { items: updated };
+      }),
+    resetPantry: () => set({ items: {} }),
   },
 }));

--- a/serverless/spoonacularProxy.ts
+++ b/serverless/spoonacularProxy.ts
@@ -1,0 +1,21 @@
+import * as functions from 'firebase-functions';
+import axios from 'axios';
+
+const SPOONACULAR_API_KEY = functions.config().spoonacular.key;
+
+export const spoonacularProxy = functions.https.onRequest(async (req, res) => {
+  try {
+    const { endpoint, ...params } = req.query as { [key: string]: string };
+    if (!endpoint) {
+      res.status(400).json({ error: 'Missing endpoint parameter' });
+      return;
+    }
+    const response = await axios.get(`https://api.spoonacular.com/${endpoint}`, {
+      params: { ...params, apiKey: SPOONACULAR_API_KEY },
+    });
+    res.json(response.data);
+  } catch (error) {
+    console.error('spoonacularProxy error', error);
+    res.status(500).json({ error: 'Failed to fetch from Spoonacular' });
+  }
+});


### PR DESCRIPTION
## Summary
- secure API key via backend proxy
- restructure pantry store to hash map
- add onboarding progress tracking
- abstract home screen logic with a custom hook
- centralize navigation routes and update navigation
- improve a11y for buttons and recipe cards
- add simple unit tests for stores

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68873965b5ec83308fd65d910dfd6478